### PR TITLE
Remove Google Plus share icons.

### DIFF
--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -13,9 +13,5 @@
       onclick="window.open(this.href, 'pinterest-share','width=580,height=296');return false;">
       <span class="hidden">Pinterest</span>
   </a>
-  <a class="icon-google-plus" style="font-size: 1.4em" href="https://plus.google.com/share?url={{ .Permalink }}"
-     onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
-      <span class="hidden">Google+</span>
-  </a>
 </section>
 {{end}}

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -68,13 +68,6 @@
 &nbsp;
 {{end}}
 
-{{ if .Site.Params.googlePlusName }}
-    <a class="bloglogo" href="https://google.com/+{{ .Site.Params.googlePlusName }}" target="_blank">
-        <span class="icon-google-plus" style="color:white;font-size:2em"></span>
-    </a>
-&nbsp;
-{{end}}
-
 {{ if .Site.Params.keybaseName }}
     <a class="bloglogo" href="https://keybase.io/{{ .Site.Params.keybaseName }}" target="_blank">
         <img src="images/keybase.svg" height="40" width="40">

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -207,9 +207,6 @@ table { border-collapse: collapse; border-spacing: 0; }
 .icon-mail:before {
     content: "\f410";
 }
-.icon-google-plus:before {
-    content: "\f206";
-}
 .icon-facebook:before {
     content: "\f203";
 }
@@ -590,8 +587,7 @@ body.nav-opened .site-wrapper {
 .main-header a.bloglogo .icon-twitter,
 .main-header a.bloglogo .icon-facebook,
 .main-header a.bloglogo .icon-instagram,
-.main-header a.bloglogo .icon-pinterest,
-.main-header a.bloglogo .icon-google-plus {
+.main-header a.bloglogo .icon-pinterest {
     color: white;
     font-size: 2em;
 }


### PR DESCRIPTION
Remove Google Plus share icons.

Google+ was shutting down at 2019/04/02.