### PR TITLE
Replace the Hugo v0.55 deprecated feature.

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -13,10 +13,10 @@
         {{ if .Site.Menus.main }}
             <a class="menu-button" href="#"><span class="burger">&#9776;</span><span class="word">Menu</span></a>
         {{else}}
-            {{ if .Site.Params.RSSLink}}
-              <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+            {{ if .Site.Params.RelPermalink}}
+              <a class="menu-button icon-feed" href="{{.Site.Params.RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
             {{else}}
-              <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+              <a class="menu-button icon-feed" href="{{ .RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
             {{end}}
         {{end}}
     </nav>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -23,10 +23,10 @@
       {{ if .Site.Menus.main }}
           <a class="menu-button" href="#"><span class="burger">&#9776;</span><span class="word">Menu</span></a>
       {{else}}
-        {{ if .Site.Params.RSSLink}}
-          <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+        {{ if .Site.Params.RelPermalink}}
+          <a class="menu-button icon-feed" href="{{.Site.Params.RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
         {{else}}
-          <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+          <a class="menu-button icon-feed" href="{{ .RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
         {{end}}
       {{end}}
     </nav>

--- a/layouts/page/cover.html
+++ b/layouts/page/cover.html
@@ -19,10 +19,10 @@
       {{ if .Site.Menus.main }}
           <a class="menu-button" href="#"><span class="burger">&#9776;</span><span class="word">Menu</span></a>
       {{else}}
-        {{ if .Site.Params.RSSLink}}
-          <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+        {{ if .Site.Params.RelPermalink}}
+          <a class="menu-button icon-feed" href="{{.Site.Params.RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
         {{else}}
-          <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+          <a class="menu-button icon-feed" href="{{ .RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
         {{end}}
       {{end}}
     </nav>

--- a/layouts/page/cover.html
+++ b/layouts/page/cover.html
@@ -79,15 +79,15 @@
 {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .)}}
       {{ range .Children }}
       <ul>
-      <li><a href="{{.URL}}">{{.Name}}</a>
+      <li><a href="{{.Permalink}}">{{.Name}}</a>
       {{ if .HasChildren }}
         <ul>
         {{ range .Children }}
-          <li><a href="{{.URL}}">{{.Name}}</a>
+          <li><a href="{{.Permalink}}">{{.Name}}</a>
           {{ if .HasChildren }}
             <ul>
             {{ range .Children }}
-            <li><a href="{{.URL}}">{{ .Name }}</a></li>
+            <li><a href="{{.Permalink}}">{{ .Name }}</a></li>
             {{ end }}
             </ul>
           {{ end }}

--- a/layouts/page/index.html
+++ b/layouts/page/index.html
@@ -17,10 +17,10 @@
         {{ if .Site.Menus.main }}
             <a class="menu-button" href="#"><span class="burger">&#9776;</span><span class="word">Menu</span></a>
         {{else}}
-            {{ if .Site.Params.RSSLink}}
-              <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+            {{ if .Site.Params.RelPermalink}}
+              <a class="menu-button icon-feed" href="{{.Site.Params.RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
             {{else}}
-              <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+              <a class="menu-button icon-feed" href="{{ .RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
             {{end}}
         {{end}}
     </nav>

--- a/layouts/page/list.html
+++ b/layouts/page/list.html
@@ -22,10 +22,10 @@
       {{ if .Site.Menus.main }}
           <a class="menu-button" href="#"><span class="burger">&#9776;</span><span class="word">Menu</span></a>
       {{else}}
-        {{ if .Site.Params.RSSLink}}
-          <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+        {{ if .Site.Params.RelPermalink}}
+          <a class="menu-button icon-feed" href="{{.Site.Params.RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
         {{else}}
-          <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+          <a class="menu-button icon-feed" href="{{ .RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
         {{end}}
       {{end}}
     </nav>

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -20,10 +20,10 @@
       {{ if .Site.Menus.main }}
           <a class="menu-button" href="#"><span class="burger">&#9776;</span><span class="word">Menu</span></a>
       {{else}}
-        {{ if .Site.Params.RSSLink}}
-          <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+        {{ if .Site.Params.RelPermalink}}
+          <a class="menu-button icon-feed" href="{{.Site.Params.RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
         {{else}}
-          <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+          <a class="menu-button icon-feed" href="{{ .RelPermalink }}">&nbsp;&nbsp;Subscribe</a>
         {{end}}
       {{end}}
     </nav>

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -57,15 +57,15 @@
         {{ $currentNode := . }}
         {{ range .Site.Menus.main }}
         {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .)}}
-        <li><a href="{{.URL}}">{{.Name}}</a></li>
+        <li><a href="{{.Permalink}}">{{.Name}}</a></li>
               {{ range .Children }}
               {{ if .HasChildren }}
               {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .)}}
-                <li><a href="{{.URL}}">{{.Name}}</a></li>
+                <li><a href="{{.Permalink}}">{{.Name}}</a></li>
                   {{ range .Children }}
                   {{ if .HasChildren }}
                   {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .)}}
-                    <li><a href="{{.URL}}">{{.Name}}</a></li>
+                    <li><a href="{{.Permalink}}">{{.Name}}</a></li>
                   {{end}}
                   {{end}}
                   {{end}}
@@ -106,7 +106,7 @@
     <!-- Children contents -->
 
     {{ range .Menus.main.Children }}
-    <li><a href="{{.URL}}" >{{ .Name }}</a></li>
+    <li><a href="{{.Permalink}}" >{{ .Name }}</a></li>
     {{ end }}
 
   </ul>
@@ -122,15 +122,15 @@
 {{if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .)}}
       {{ range .Children }}
       <ul>
-      <li><a href="{{.URL}}">{{.Name}}</a>
+      <li><a href="{{.Permalink}}">{{.Name}}</a>
       {{ if .HasChildren }}
         <ul>
         {{ range .Children }}
-          <li><a href="{{.URL}}">{{.Name}}</a>
+          <li><a href="{{.Permalink}}">{{.Name}}</a>
           {{ if .HasChildren }}
             <ul>
             {{ range .Children }}
-            <li><a href="{{.URL}}">{{ .Name }}</a></li>
+            <li><a href="{{.Permalink}}">{{ .Name }}</a></li>
             {{ end }}
             </ul>
           {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -64,14 +64,14 @@
         <script>hljs.initHighlightingOnLoad();</script>
     {{end}}
 
-    {{ if .Site.Params.RSSLink}}
-        <link href="{{.Site.Params.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    {{ if .Site.Params.RelPermalink}}
+        <link href="{{.Site.Params.RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{else}}
       {{ if ne .URL "/" }}
           <link href="{{ "index.xml" | relURL}}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
       {{ end }}
       {{if .IsNode}}
-        <link href="{{.RSSLink}}" rel="alternate" type="application/rss+xml" title="{{ if ne .URL "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
+        <link href="{{.RelPermalink}}" rel="alternate" type="application/rss+xml" title="{{ if ne .URL "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
       {{end}}
     {{end}}
     {{.Hugo.Generator}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -74,7 +74,7 @@
         <link href="{{.RelPermalink}}" rel="alternate" type="application/rss+xml" title="{{ if ne .Permalink "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
       {{end}}
     {{end}}
-    {{.Hugo.Generator}}
+    {{ hugo.Generator }}
 
     <link rel="canonical" href="{{ .Permalink }}" />
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
 
     {{ partial "twitter_card.html" . }}
 
-  	<meta property="og:title" content="{{ if ne .URL "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
+  	<meta property="og:title" content="{{ if ne .Permalink "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
   	<meta property="og:site_name" content="{{ .Site.Title }}" />
   	<meta property="og:url" content="{{ .Permalink }}" />
 
@@ -32,7 +32,7 @@
     <meta property="og:description" content="{{ .Site.Params.description }}" />
     {{ end }}
 
-    <title>{{ if ne .URL "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}</title>
+    <title>{{ if ne .Permalink "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}</title>
 
     {{ if .IsPage }}
     <meta name="description" content="{{ .Description | default (substr .Summary 0 160) }}" />
@@ -67,11 +67,11 @@
     {{ if .Site.Params.RelPermalink}}
         <link href="{{.Site.Params.RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{else}}
-      {{ if ne .URL "/" }}
+      {{ if ne .Permalink "/" }}
           <link href="{{ "index.xml" | relURL}}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
       {{ end }}
       {{if .IsNode}}
-        <link href="{{.RelPermalink}}" rel="alternate" type="application/rss+xml" title="{{ if ne .URL "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
+        <link href="{{.RelPermalink}}" rel="alternate" type="application/rss+xml" title="{{ if ne .Permalink "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
       {{end}}
     {{end}}
     {{.Hugo.Generator}}

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -15,10 +15,10 @@
         {{end}}
     </ul>
 
-    {{ if .Site.Params.RSSLink}}
-    <a class="subscribe-button icon-feed" href="{{.Site.Params.RSSLink }}">Subscribe</a> </div>
+    {{ if .Site.Params.RelPermalink}}
+    <a class="subscribe-button icon-feed" href="{{.Site.Params.RelPermalink }}">Subscribe</a> </div>
     {{else}}
-    <a class="subscribe-button icon-feed" href="{{if .IsNode}}{{.RSSLink}}{{else}}{{"index.xml" | relURL}}{{end}}">Subscribe</a>
+    <a class="subscribe-button icon-feed" href="{{if .IsNode}}{{.RelPermalink}}{{else}}{{"index.xml" | relURL}}{{end}}">Subscribe</a>
     {{end}}
 </div>
 <span class="nav-cover"></span>


### PR DESCRIPTION
Replace the Hugo v0.55 deprecated feature.

- Replace the `.RSSLink` by `.RelPermalink`.
- Replace the `.URL` by `.Permalink`.
- Replace the `.Hugo.Generator` by `hugo.Generator`.